### PR TITLE
Added Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: android
+jdk: oraclejdk7
+
+android:
+  components:
+    - build-tools-22.0.1
+    - android-22 #SDK
+
+script: ./gradlew build


### PR DESCRIPTION
Travis CI configuration should be updated alongside with build.gradle (SDK and build-tools versions).